### PR TITLE
security: remove hardcoded Publer API fallback

### DIFF
--- a/.github/workflows/cerberus-go-live-ci.yml
+++ b/.github/workflows/cerberus-go-live-ci.yml
@@ -6,6 +6,8 @@ on:
       - 'skills/cerberus-go-live-workflow.ts'
       - 'cerberus-go-live.ts'
       - 'test-cerberus-go-live.ts'
+      - 'test-social-hub-config-security.ts'
+      - 'skills/social-hub-config.ts'
       - 'config/cerberus-go-live.rota.json'
       - 'package.json'
       - '.github/workflows/cerberus-go-live-ci.yml'
@@ -25,4 +27,5 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test:cerberus
+      - run: npm run test:security-config
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:cerberus": "ts-node --transpile-only test-cerberus-go-live.ts",
     "smoke": "ts-node scripts/smoke-boot-simple.ts",
     "smoke:skills": "ts-node --transpile-only scripts/smoke-skills-count.ts",
-    "skills:list": "ts-node --transpile-only -e \"const s=require('./skills'); const r=s.registerAllSkills(); r.listAll().forEach((x)=>console.log((x.name),' - ',(x.description||'')))\""
+    "skills:list": "ts-node --transpile-only -e \"const s=require('./skills'); const r=s.registerAllSkills(); r.listAll().forEach((x)=>console.log((x.name),' - ',(x.description||'')))\"",
+    "test:security-config": "ts-node --transpile-only test-social-hub-config-security.ts"
   },
   "keywords": [
     "openclaw",

--- a/skills/social-hub-config.ts
+++ b/skills/social-hub-config.ts
@@ -38,7 +38,7 @@ export interface SocialHubConfig {
 export function loadSocialHubConfig(): SocialHubConfig {
   // Tentar carregar de variáveis de ambiente primeiro
   const config: SocialHubConfig = {
-    publisherApiKey: process.env.PUBLER_API_KEY || 'cb8e8eda44390f8878f5b5ad9ddd19d84c165748e5b65a09',
+    publisherApiKey: process.env.PUBLER_API_KEY || '',
     anthropicApiKey: process.env.ANTHROPIC_API_KEY || '',
 
     instagramAccessToken: process.env.INSTAGRAM_ACCESS_TOKEN,

--- a/test-social-hub-config-security.ts
+++ b/test-social-hub-config-security.ts
@@ -1,0 +1,17 @@
+﻿import assert from 'assert';
+import { loadSocialHubConfig } from './skills/social-hub-config';
+
+function testPublerKeyHasNoHardcodedFallback(): void {
+  const previous = process.env.PUBLER_API_KEY;
+  try {
+    delete process.env.PUBLER_API_KEY;
+    const config = loadSocialHubConfig();
+    assert.strictEqual(config.publisherApiKey, '', 'PUBLER_API_KEY must be empty when env is unset');
+  } finally {
+    if (previous === undefined) delete process.env.PUBLER_API_KEY;
+    else process.env.PUBLER_API_KEY = previous;
+  }
+}
+
+testPublerKeyHasNoHardcodedFallback();
+console.log('Social Hub config security test passed');


### PR DESCRIPTION
## Summary
- removes the versioned Publer API fallback from Social Hub config
- requires PUBLER_API_KEY through the environment
- adds a regression test
- runs the security test in Cerberus CI

## Verification
- npm run test:security-config
- npm run test:cerberus
- npm run build
- hardcoded fallback scan: no match

## Required operator action
Rotate the previously versioned Publer credential if it was active. The value is intentionally not included in this PR description.